### PR TITLE
Stop and cycle

### DIFF
--- a/android/src/main/java/tor/plugin/OnionProxyManager.java
+++ b/android/src/main/java/tor/plugin/OnionProxyManager.java
@@ -439,7 +439,7 @@ public abstract class OnionProxyManager {
         return onionProxyContext.getWorkingDirectory();
     }
 
-    public boolean newIdentity(){
+    public boolean newnym(){
         try {
             controlConnection.signal("NEWNYM");
             return true;

--- a/android/src/main/java/tor/plugin/OnionProxyManager.java
+++ b/android/src/main/java/tor/plugin/OnionProxyManager.java
@@ -441,7 +441,6 @@ public abstract class OnionProxyManager {
 
     public boolean newIdentity(){
         try {
-
             controlConnection.signal("NEWNYM");
             return true;
         } catch (IOException e) {

--- a/android/src/main/java/tor/plugin/TorPlugin.java
+++ b/android/src/main/java/tor/plugin/TorPlugin.java
@@ -13,10 +13,10 @@ public class TorPlugin extends Plugin {
     private static final int TOTAL_SECONDS_PER_TOR_STARTUP = 240;
     private static final int TOTAL_TRIES_PER_TOR_STARTUP = 5;
     private static final int DEFAULT_SOCKS_PORT = 9050;
+    private final OnionProxyManager manager = new AndroidOnionProxyManager(getContext(), "torfiles");
 
     @PluginMethod()
     public void initTor(PluginCall call) throws IOException, InterruptedException {
-        OnionProxyManager manager = new AndroidOnionProxyManager(getContext(), "torfiles");
         Integer socksPort = call.getInt("socksPort");
         if(socksPort == null){
             socksPort = DEFAULT_SOCKS_PORT;
@@ -41,5 +41,39 @@ public class TorPlugin extends Plugin {
 
         call.success();
     }
+
+    @PluginMethod()
+    public void stop(PluginCall call) throws IOException {
+        manager.stop();
+        call.success();
+    }
+
+//    @PluginMethod()
+//    public void stop(PluginCall call) throws IOException, InterruptedException {
+//        OnionProxyManager manager = new AndroidOnionProxyManager(getContext(), "torfiles");
+//        Integer socksPort = call.getInt("socksPort");
+//        if(socksPort == null){
+//            socksPort = DEFAULT_SOCKS_PORT;
+//        }
+//
+//        manager.startWithRepeat(socksPort, TOTAL_SECONDS_PER_TOR_STARTUP, TOTAL_TRIES_PER_TOR_STARTUP,
+//            new OnionProxyManagerEventHandler() {
+//                @Override
+//                public void message(String severity, String msg){
+//                    super.message(severity, msg);
+//                    if(msg.contains("Bootstrapped")){
+//                        try {
+//                            String percentStr = msg.split(" ")[1];
+//                            String percent = percentStr.substring(0, percentStr.length() - 1);
+//                            JSObject ret = new JSObject();
+//                            ret.put("progress", percent);
+//                            notifyListeners("torInitProgress", ret);
+//                        } catch (Exception ignored) { }
+//                    }
+//                }
+//        });
+//
+//        call.success();
+//    }
 }
 

--- a/android/src/main/java/tor/plugin/TorPlugin.java
+++ b/android/src/main/java/tor/plugin/TorPlugin.java
@@ -13,7 +13,7 @@ public class TorPlugin extends Plugin {
     private static final int TOTAL_SECONDS_PER_TOR_STARTUP = 240;
     private static final int TOTAL_TRIES_PER_TOR_STARTUP = 5;
     private static final int DEFAULT_SOCKS_PORT = 9050;
-    private final OnionProxyManager manager = new AndroidOnionProxyManager(getContext(), "torfiles");
+    private OnionProxyManager manager;
 
     @PluginMethod()
     public void initTor(PluginCall call) throws IOException, InterruptedException {
@@ -22,7 +22,7 @@ public class TorPlugin extends Plugin {
             socksPort = DEFAULT_SOCKS_PORT;
         }
 
-        manager.startWithRepeat(socksPort, TOTAL_SECONDS_PER_TOR_STARTUP, TOTAL_TRIES_PER_TOR_STARTUP,
+        getManager().startWithRepeat(socksPort, TOTAL_SECONDS_PER_TOR_STARTUP, TOTAL_TRIES_PER_TOR_STARTUP,
             new OnionProxyManagerEventHandler() {
                 @Override
                 public void message(String severity, String msg){
@@ -44,8 +44,15 @@ public class TorPlugin extends Plugin {
 
     @PluginMethod()
     public void stop(PluginCall call) throws IOException {
-        manager.stop();
+        getManager().stop();
         call.success();
+    }
+
+    private OnionProxyManager getManager() {
+        if(manager == null){
+            manager = new AndroidOnionProxyManager(getContext(), "torfiles");
+        }
+        return manager;
     }
 
 //    @PluginMethod()

--- a/android/src/main/java/tor/plugin/TorPlugin.java
+++ b/android/src/main/java/tor/plugin/TorPlugin.java
@@ -16,7 +16,7 @@ public class TorPlugin extends Plugin {
     private OnionProxyManager manager;
 
     @PluginMethod()
-    public void initTor(PluginCall call) throws IOException, InterruptedException {
+    public void start(PluginCall call) throws IOException, InterruptedException {
         Integer socksPort = call.getInt("socksPort");
         if(socksPort == null){
             socksPort = DEFAULT_SOCKS_PORT;
@@ -42,10 +42,32 @@ public class TorPlugin extends Plugin {
         call.success();
     }
 
+    // Kills running tor daemon
     @PluginMethod()
     public void stop(PluginCall call) throws IOException {
-        getManager().stop();
+        OnionProxyManager manager = getManager();
+        if(manager.isRunning()){
+            manager.stop();
+        }
         call.success();
+    }
+
+    // Reset tor chain
+    @PluginMethod()
+    public void newnym(PluginCall call) throws IOException {
+        OnionProxyManager manager = getManager();
+        if(manager.isRunning()){
+            manager.newnym();
+        }
+        call.success();
+    }
+
+    @PluginMethod()
+    public void running(PluginCall call) throws IOException {
+        boolean running = getManager().isRunning();
+        JSObject object = new JSObject();
+        object.put("running", running);
+        call.success(object);
     }
 
     private OnionProxyManager getManager() {

--- a/android/src/main/java/tor/plugin/TorPlugin.java
+++ b/android/src/main/java/tor/plugin/TorPlugin.java
@@ -13,6 +13,7 @@ public class TorPlugin extends Plugin {
     private static final int TOTAL_SECONDS_PER_TOR_STARTUP = 240;
     private static final int TOTAL_TRIES_PER_TOR_STARTUP = 5;
     private static final int DEFAULT_SOCKS_PORT = 9050;
+
     private OnionProxyManager manager;
 
     @PluginMethod()
@@ -22,22 +23,12 @@ public class TorPlugin extends Plugin {
             socksPort = DEFAULT_SOCKS_PORT;
         }
 
-        getManager().startWithRepeat(socksPort, TOTAL_SECONDS_PER_TOR_STARTUP, TOTAL_TRIES_PER_TOR_STARTUP,
-            new OnionProxyManagerEventHandler() {
-                @Override
-                public void message(String severity, String msg){
-                    super.message(severity, msg);
-                    if(msg.contains("Bootstrapped")){
-                        try {
-                            String percentStr = msg.split(" ")[1];
-                            String percent = percentStr.substring(0, percentStr.length() - 1);
-                            JSObject ret = new JSObject();
-                            ret.put("progress", percent);
-                            notifyListeners("torInitProgress", ret);
-                        } catch (Exception ignored) { }
-                    }
-                }
-        });
+        getManager().startWithRepeat(
+            socksPort, 
+            TOTAL_SECONDS_PER_TOR_STARTUP, 
+            TOTAL_TRIES_PER_TOR_STARTUP,
+            STARTUP_EVENT_HANDLER
+        );
 
         call.success();
     }
@@ -77,32 +68,21 @@ public class TorPlugin extends Plugin {
         return manager;
     }
 
-//    @PluginMethod()
-//    public void stop(PluginCall call) throws IOException, InterruptedException {
-//        OnionProxyManager manager = new AndroidOnionProxyManager(getContext(), "torfiles");
-//        Integer socksPort = call.getInt("socksPort");
-//        if(socksPort == null){
-//            socksPort = DEFAULT_SOCKS_PORT;
-//        }
-//
-//        manager.startWithRepeat(socksPort, TOTAL_SECONDS_PER_TOR_STARTUP, TOTAL_TRIES_PER_TOR_STARTUP,
-//            new OnionProxyManagerEventHandler() {
-//                @Override
-//                public void message(String severity, String msg){
-//                    super.message(severity, msg);
-//                    if(msg.contains("Bootstrapped")){
-//                        try {
-//                            String percentStr = msg.split(" ")[1];
-//                            String percent = percentStr.substring(0, percentStr.length() - 1);
-//                            JSObject ret = new JSObject();
-//                            ret.put("progress", percent);
-//                            notifyListeners("torInitProgress", ret);
-//                        } catch (Exception ignored) { }
-//                    }
-//                }
-//        });
-//
-//        call.success();
-//    }
+    private OnionProxyManagerEventHandler STARTUP_EVENT_HANDLER = new OnionProxyManagerEventHandler() {
+        @Override
+        public void message(String severity, String msg){
+            super.message(severity, msg);
+            if(msg.contains("Bootstrapped")){
+                try {
+                    String percentStr = msg.split(" ")[1];
+                    String percent = percentStr.substring(0, percentStr.length() - 1);
+                    JSObject ret = new JSObject();
+                    ret.put("progress", percent);
+                    notifyListeners("torInitProgress", ret);
+                } catch (Exception ignored) { }
+            }
+        }
+    };
+
 }
 

--- a/ios/Plugin/OnionConnector.swift
+++ b/ios/Plugin/OnionConnector.swift
@@ -16,10 +16,10 @@ public final class OnionConnecter {
 
     public init() {}
 
-    public func start(socksPort: Int, progress: ((Int) -> Void)?, completion: @escaping (Result<URLSessionConfiguration, OnionError>) -> Void) {
+    public func start(manager: OnionManager, socksPort: Int, progress: ((Int) -> Void)?, completion: @escaping (Result<URLSessionConfiguration, OnionError>) -> Void) {
         self.progress = progress
         self.completion = completion
-        OnionManager.shared.startTor(socksPort: socksPort, delegate: self)
+        manager.startTor(socksPort: socksPort, delegate: self)
     }
 }
 

--- a/ios/Plugin/OnionManager.swift
+++ b/ios/Plugin/OnionManager.swift
@@ -91,7 +91,7 @@ public class OnionManager: NSObject {
 
     @objc func networkChange() {
         var confs: [Dictionary<String, String>] = []
-
+        
         confs.append(["key": "ClientPreferIPv6DirPort", "value": "auto"])
         confs.append(["key": "ClientPreferIPv6ORPort", "value": "auto"])
         confs.append(["key": "clientuseipv4", "value": "1"])
@@ -255,12 +255,22 @@ public class OnionManager: NSObject {
         // we actually rely on that to stop tor and reset the state of torController. (we can
         // SIGNAL SHUTDOWN here, but we can't reset the torController "isConnected" state.)
         self.torController?.disconnect()
-
+//        self.torController?.sendCommand("SIGNAL SHUTDOWN", arguments: nil, data: nil, observer: { _, _, _ -> Bool in
+//            true
+//        })
         self.torController = nil
-
         // More cleanup
         self.torThread?.cancel()
+        self.torThread = nil
         self.state = .stopped
+    }
+    
+    @objc func running() -> Bool {
+        if let ret = self.torThread {
+          return ret.isExecuting
+        } else {
+          return false
+        }
     }
 
     /**

--- a/ios/Plugin/Plugin.m
+++ b/ios/Plugin/Plugin.m
@@ -4,5 +4,8 @@
 // Define the plugin using the CAP_PLUGIN Macro, and
 // each method the plugin supports using the CAP_PLUGIN_METHOD macro.
 CAP_PLUGIN(TorPlugin, "TorPlugin",
-    CAP_PLUGIN_METHOD(initTor, CAPPluginReturnPromise);
+    CAP_PLUGIN_METHOD(start, CAPPluginReturnPromise);
+    CAP_PLUGIN_METHOD(stop, CAPPluginReturnPromise);
+    CAP_PLUGIN_METHOD(running, CAPPluginReturnPromise);
+    CAP_PLUGIN_METHOD(newnym, CAPPluginReturnPromise);
 )

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -9,15 +9,15 @@ import Tor
  */
 @objc(TorPlugin)
 public class TorPlugin: CAPPlugin {
-    var onionConnector: OnionManager? = nil
     var urlSessionConfiguration: URLSessionConfiguration? = nil
     var restClient: Rest? = nil
     var fdTable: [Int32: Socket] = [:]
+    let onionConnector = OnionConnecter.init()
+    let onionManager = OnionManager.shared
     
-    @objc func initTor(_ call: CAPPluginCall) {
+    @objc func start(_ call: CAPPluginCall) {
         let socksPort = call.getInt("socksPort") ?? 9050
-        let onionConnector = OnionConnecter.init()
-        onionConnector.start(socksPort: socksPort, progress: { (i: Int) in
+        onionConnector.start(manager: onionManager, socksPort: socksPort, progress: { (i: Int) in
             print(i)
             self.notifyListeners("torInitProgress", data: ["progress" : String(i)])
         }, completion: { result in
@@ -29,7 +29,26 @@ public class TorPlugin: CAPPlugin {
                 call.error(error.localizedDescription)
             }
         })
+        
     }
+    
+    //    stop()   : Promise<void>
+    @objc func stop(_ call: CAPPluginCall) {
+        onionManager.stopTor()
+        call.resolve()
+    }
+
+    //    newnym() : Promise<void>
+    @objc func newnym(_ call: CAPPluginCall) {
+        onionManager.torReconnect()
+        call.resolve()
+    }
+
+    //    running(): Promise<{running: boolean}>
+    @objc func running(_ call: CAPPluginCall) {
+        call.resolve(["running" : onionManager.running()])
+    }
+
 }
 
 extension Data {

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -5,6 +5,7 @@ def capacitor_pods
   use_frameworks!
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
+  
 end
 
 target 'Plugin' do

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capacitor-tor",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "tor plugin for the capacitor",
   "main": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -9,4 +9,6 @@ declare module "@capacitor/core" {
 
 export interface TorPlugin {
   initTor(opt?: { socksPort: number }): Observable<number>;
+  stop()  : Promise<void> 
+  newnym(): Promise<void> 
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -8,7 +8,8 @@ declare module "@capacitor/core" {
 }
 
 export interface TorPlugin {
-  initTor(opt?: { socksPort: number }): Observable<number>;
-  stop()  : Promise<void> 
-  newnym(): Promise<void> 
+  start(opt?: { socksPort: number }): Observable<number>
+  stop()   : Promise<void>
+  newnym() : Promise<void>
+  running(): Promise<{running: boolean}>
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -7,7 +7,7 @@ const { TorPlugin : TorNative } = Plugins;
 export class Tor implements TorPlugin {
   constructor() {}
 
-  initTor(opt?: { socksPort: number }): Observable<number> {
+  start(opt?: { socksPort: number }): Observable<number> {
     const initProgress = new Subject<number>()
     
     const eventListener = TorNative.addListener("torInitProgress", info => {
@@ -18,7 +18,7 @@ export class Tor implements TorPlugin {
       }
     })
 
-    TorNative.initTor(opt)
+    TorNative.start(opt)
     return initProgress
   }
 
@@ -28,5 +28,9 @@ export class Tor implements TorPlugin {
 
   newnym(): Promise<void> {
     return TorNative.newnym()
+  }
+  
+  running(): Promise<{running: boolean}> {
+    return TorNative.running()
   }
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -21,4 +21,12 @@ export class Tor implements TorPlugin {
     TorNative.initTor(opt)
     return initProgress
   }
+
+  stop(): Promise<void> {
+    return TorNative.stop()
+  }
+
+  newnym(): Promise<void> {
+    return TorNative.newnym()
+  }
 }


### PR DESCRIPTION
### Testing this code

_Test this with stopAndCycleTesting branch of tor-playground:_ https://github.com/Start9Labs/tor-playground/tree/stopAndCycleTesting

_Of course when you pull that down checkout your package.json and make sure local file deps line up._

### Purpose 

Add stop, cycle (newnym), and running (is tor running?) functions to the capacitor-tor plugin.

### As of 5/1/2020 here is the state of this thing.

All functionality works for android.
All functionality works for ios, but, there's a bug.

**IOS Bug:** start followed by stop followed by start crashes the app. For some reason, the second start call attempts to open the socks listener twice in a row. Naturally, the second attempt blows up with an address already in use error. I've recorded logs emitting from the start method first when things are good (when the app first starts up), and second when we call start again after having stopped it once before below.

I don't know what's going on. However, my last intelligible thought on the matter was in OnionManager.swift. On line 130 (within the `startTor` method) it grabs the static variable `torBaseConf`. Now `torBaseConf` is the result of a closure beginning on line 32 in the same file. I'm not sure that closure is re-run the second time we call startTor... it might instead be coming from a cache. Perhaps this explain the different behavior?

HEALTHY STARTUP LOGS

> To Native ->  TorPlugin start 14963587
> [OnionManager] dataDir=file:///Users/aarongreenspan/Library/Developer/CoreSimulator/Devices/B16C86D2-5486-49C1-A1A8-CC0FF5394972/data/Containers/Data/Application/7C770955-15FD-476D-8976-C954C227413B/Library/Caches/tor/
> "\n\n[\"--allow-missing-torrc\", \"--ignore-missing-torrc\", \"--controlport\", \"127.0.0.1:39060\", \"--log\", \"notice stdout\", \"--ClientOnionAuthDir\", \"/Users/aarongreenspan/Library/Developer/CoreSimulator/Devices/B16C86D2-5486-49C1-A1A8-CC0FF5394972/data/Containers/Data/Application/7C770955-15FD-476D-8976-C954C227413B/Library/Caches/tor/auth\", \"--socksport\", \"127.0.0.1:59590\"]\n\n"
> [OnionManager] Starting Tor
> Apr 30 23:17:26.929 [notice] Tor 0.4.0.6 (git-39344e410dca1dd4) running on Darwin with Libevent 2.1.11-stable, OpenSSL 1.1.1d, Zlib 1.2.11, Liblzma 5.2.4, and Libzstd N/A.
> Apr 30 23:17:26.929 [notice] Tor can't help you if you use it wrong! Learn how to be safe at https://www.torproject.org/download/download#warning
> Apr 30 23:17:26.930 [notice] Configuration file "/Users/aarongreenspan/Library/Developer/CoreSimulator/Devices/B16C86D2-5486-49C1-A1A8-CC0FF5394972/data/Containers/Data/Application/7C770955-15FD-476D-8976-C954C227413B/.torrc" not present, using reasonable defaults.
> Apr 30 23:17:26.938 [notice] Opening Socks listener on 127.0.0.1:59590
> Apr 30 23:17:26.939 [notice] Opened Socks listener on 127.0.0.1:59590
> Apr 30 23:17:26.939 [notice] Opening Control listener on 127.0.0.1:39060
> Apr 30 23:17:26.939 [notice] Opened Control listener on 127.0.0.1:39060
> Apr 30 23:17:27.000 [notice] Bootstrapped 0% (starting): Starting
> Apr 30 23:17:27.000 [notice] Starting with guard context "default"
> Apr 30 23:17:27.000 [notice] Bootstrapped 5% (conn): Connecting to a relay
> Apr 30 23:17:28.000 [notice] New control connection opened from 127.0.0.1.
> [OnionManager] cookieURL= file:///Users/aarongreenspan/Library/Developer/CoreSimulator/Devices/B16C86D2-5486-49C1-A1A8-CC0FF5394972/data/Containers/Data/Application/7C770955-15FD-476D-8976-C954C227413B/Library/Caches/tor/control_auth_cookie
> [OnionManager] cookie= 32 bytes
> Apr 30 23:17:28.000 [notice] Bootstrapped 10% (conn_done): Connected to a relay
> [OnionManager] progress=10
> 

...

UNHEALTHY STARTUP LOGS (after having stopped a previous instance)

> To Native ->  TorPlugin start 14963591
> "\n\n[\"--allow-missing-torrc\", \"--ignore-missing-torrc\", \"--controlport\", \"127.0.0.1:39060\", \"--log\", \"notice stdout\", \"--ClientOnionAuthDir\", \"/Users/aarongreenspan/Library/Developer/CoreSimulator/Devices/B16C86D2-5486-49C1-A1A8-CC0FF5394972/data/Containers/Data/Application/7C770955-15FD-476D-8976-C954C227413B/Library/Caches/tor/auth\", \"--socksport\", \"127.0.0.1:59590\", \"--socksport\", \"127.0.0.1:59590\"]\n\n"
> [OnionManager] Starting Tor
> Apr 30 23:17:39.000 [notice] Tor 0.4.0.6 (git-39344e410dca1dd4) running on Darwin with Libevent 2.1.11-stable, OpenSSL 1.1.1d, Zlib 1.2.11, Liblzma 5.2.4, and Libzstd N/A.
> Apr 30 23:17:39.000 [notice] Tor can't help you if you use it wrong! Learn how to be safe at https://www.torproject.org/download/download#warning
> Apr 30 23:17:39.000 [notice] Configuration file "/Users/aarongreenspan/Library/Developer/CoreSimulator/Devices/B16C86D2-5486-49C1-A1A8-CC0FF5394972/data/Containers/Data/Application/7C770955-15FD-476D-8976-C954C227413B/.torrc" not present, using reasonable defaults.
> Apr 30 23:17:39.000 [notice] Opening Socks listener on 127.0.0.1:59590
> Apr 30 23:17:39.000 [notice] Opened Socks listener on 127.0.0.1:59590
> **Apr 30 23:17:39.000 [notice] Opening Socks listener on 127.0.0.1:59590**
> Apr 30 23:17:39.000 [warn] Could not bind to 127.0.0.1:59590: Address already in use. Is Tor already running?
> Apr 30 23:17:39.000 [notice] Opening Control listener on 127.0.0.1:39060
> Apr 30 23:17:39.000 [notice] Opened Control listener on 127.0.0.1:39060
> Apr 30 23:17:39.000 [notice] Closing partially-constructed Socks listener on 127.0.0.1:59590
> Apr 30 23:17:39.000 [notice] Closing partially-constructed Control listener on 127.0.0.1:39060
> Apr 30 23:17:39.000 [warn] Failed to parse/validate config: Failed to bind one of the listener ports.
> Apr 30 23:17:39.000 [err] Reading config failed--see warnings above.
> 